### PR TITLE
Loosen thor dependency

### DIFF
--- a/coconductor.gemspec
+++ b/coconductor.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'licensee', '~> 9.9', '>= 9.9.4'
-  spec.add_dependency 'thor', '~> 0.18'
+  spec.add_dependency 'thor', '>= 0.18', '< 2.0'
   spec.add_dependency 'toml', '~> 0.2'
 
   spec.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
Railties for Rails 6 thor dependency is `s.add_dependency "thor", ">=
0.20.3", "< 2.0"` so this PR relaxes coconductor's thor dependency so it
can work with Rails 5.2+.

cc/ @benbalter 